### PR TITLE
Fix "name"->"id" Warning

### DIFF
--- a/module.json
+++ b/module.json
@@ -1,9 +1,9 @@
 {
-  "name": "pf2e-exploration-activities",
+  "id": "pf2e-exploration-activities",
   "title": "PF2e Exploration Activities",
   "description": "Exploration Activity Macros, linked to Exploration Effects",
   "authors": [{ "name": "IcyLemon" }],
-  "version": "1.2.1",
+  "version": "1.2.2",
   "compatibility": {
     "minimum": "10",
     "verified": "10"


### PR DESCRIPTION
The use of "name" prompts a Foundry deprecation warning. Updating to "id" removes it. I also incremented to 1.2.2 in this change.