### PR TITLE
Only one effect

### DIFF
--- a/module.json
+++ b/module.json
@@ -3,7 +3,7 @@
   "title": "PF2e Exploration Activities",
   "description": "Exploration Activity Macros, linked to Exploration Effects",
   "authors": [{ "name": "IcyLemon" }],
-  "version": "1.2.1",
+  "version": "1.2.2",
   "compatibility": {
     "minimum": "10",
     "verified": "10"

--- a/scripts/player-exploration-effects-macro.js
+++ b/scripts/player-exploration-effects-macro.js
@@ -98,6 +98,7 @@ function explorationActivity(actor, tokenID) {
           selectedActivity =
             '<h3>I will <b>' + html.find('#activity')[0].value + '</b></h3>'
           generateChat(actor, selectedActivity)
+          removeExplorationEffects(actor)
           applyEffect(actor, html.find('#activity')[0].value)
         },
       },
@@ -127,40 +128,53 @@ function explorationActivity(actor, tokenID) {
     await ChatMessage.create(chatData, {})
   }
 
+
+  const explorationEffects = {
+    'Avoid Notice':
+      'Compendium.pf2e-exploration-effects.exploration-effects.N8vpuGy4TzU10y8E',
+    'Cover Tracks':
+      'Compendium.pf2e-exploration-effects.exploration-effects.F6vJYLZTWDpnrnCZ',
+    'Defend':
+      'Compendium.pf2e-exploration-effects.exploration-effects.GYOyFj4ziZX060rZ',
+    'Detect Magic':
+      'Compendium.pf2e-exploration-effects.exploration-effects.OjRHL0B4WAUUQc13',
+    'Follow the Expert':
+      'ompendium.pf2e-exploration-effects.exploration-effects.V347nnVBGDrVWh7k',
+    'Hustle':
+      'Compendium.pf2e-exploration-effects.exploration-effects.vNUrKvoOSvEnqzhM',
+    'Investigate':
+      'Compendium.pf2e-exploration-effects.exploration-effects.tDsgl8YmhZbx2May',
+    'Repeat a Spell':
+      'Compendium.pf2e-exploration-effects.exploration-effects.kh1QdKkvbNZ0qBsQ',
+    'Scout':
+      'Compendium.pf2e-exploration-effects.exploration-effects.mGFBHM1lvHNZ9BsH',
+    'Search':
+      'Compendium.pf2e-exploration-effects.exploration-effects.XiVLHjg5lQVMX8Fj',
+    'Track':
+      'Compendium.pf2e-exploration-effects.exploration-effects.OcCXjJab7rSR3mDf',
+  }
+
   //used to apply effect
   async function applyEffect(actor, selectedEffect) {
     const re = /\{(.*)\}/i
     let effectName = selectedEffect.match(re)[1]
-    const explorationEffects = {
-      'Avoid Notice':
-        'Compendium.pf2e-exploration-effects.exploration-effects.N8vpuGy4TzU10y8E',
-      'Cover Tracks':
-        'Compendium.pf2e-exploration-effects.exploration-effects.F6vJYLZTWDpnrnCZ',
-      Defend:
-        'Compendium.pf2e-exploration-effects.exploration-effects.GYOyFj4ziZX060rZ',
-      'Detect Magic':
-        'Compendium.pf2e-exploration-effects.exploration-effects.OjRHL0B4WAUUQc13',
-      'Follow the Expert':
-        'ompendium.pf2e-exploration-effects.exploration-effects.V347nnVBGDrVWh7k',
-      Hustle:
-        'Compendium.pf2e-exploration-effects.exploration-effects.vNUrKvoOSvEnqzhM',
-      Investigate:
-        'Compendium.pf2e-exploration-effects.exploration-effects.tDsgl8YmhZbx2May',
-      'Repeat a Spell':
-        'Compendium.pf2e-exploration-effects.exploration-effects.kh1QdKkvbNZ0qBsQ',
-      Scout:
-        'Compendium.pf2e-exploration-effects.exploration-effects.mGFBHM1lvHNZ9BsH',
-      Search:
-        'Compendium.pf2e-exploration-effects.exploration-effects.XiVLHjg5lQVMX8Fj',
-      Track:
-        'Compendium.pf2e-exploration-effects.exploration-effects.OcCXjJab7rSR3mDf',
-    }
-
     let effect = explorationEffects[effectName]
     if (effect != undefined) {
       console.log('the effect is ' + effect)
       let item = (await fromUuid(effect)).toObject()
       await token.actor.createEmbeddedDocuments('Item', [item])
+    }
+  }
+
+  //removes other exploration activities
+  async function removeExplorationEffects(actor) {
+    for (const effectName of Object.keys(explorationEffects)) {
+      for (const fx of token.actor.itemTypes.effect) {
+        if (fx.name == effectName) {
+          console.log('removing ' + fx.name)
+          await fx.delete()
+        }
+      }
     }
   }
 }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -87,6 +87,7 @@ export function explorationActivity(actor, tokenID) {
           selectedActivity =
             '<h3>I will <b>' + html.find('#activity')[0].value + '</b></h3>'
           generateChat(actor, selectedActivity)
+          removeOtherEffects(actor)
           applyEffect(actor, html.find('#activity')[0].value)
         },
       },
@@ -116,41 +117,53 @@ export function explorationActivity(actor, tokenID) {
     await ChatMessage.create(chatData, {})
   }
 
+  const explorationEffects = {
+    'Avoid Notice':
+      'Compendium.pf2e-exploration-effects.exploration-effects.N8vpuGy4TzU10y8E',
+    'Cover Tracks':
+      'Compendium.pf2e-exploration-effects.exploration-effects.F6vJYLZTWDpnrnCZ',
+    Defend:
+      'Compendium.pf2e-exploration-effects.exploration-effects.GYOyFj4ziZX060rZ',
+    'Detect Magic':
+      'Compendium.pf2e-exploration-effects.exploration-effects.OjRHL0B4WAUUQc13',
+    'Follow the Expert':
+      'ompendium.pf2e-exploration-effects.exploration-effects.V347nnVBGDrVWh7k',
+    Hustle:
+      'Compendium.pf2e-exploration-effects.exploration-effects.vNUrKvoOSvEnqzhM',
+    Investigate:
+      'Compendium.pf2e-exploration-effects.exploration-effects.tDsgl8YmhZbx2May',
+    'Repeat a Spell':
+      'Compendium.pf2e-exploration-effects.exploration-effects.kh1QdKkvbNZ0qBsQ',
+    Scout:
+      'Compendium.pf2e-exploration-effects.exploration-effects.mGFBHM1lvHNZ9BsH',
+    Search:
+      'Compendium.pf2e-exploration-effects.exploration-effects.XiVLHjg5lQVMX8Fj',
+    Track:
+      'Compendium.pf2e-exploration-effects.exploration-effects.OcCXjJab7rSR3mDf',
+    Unspecified:
+      'Compendium.pf2e-exploration-effects.exploration-effects.CcyA2CzeaTBWHNHP',
+  }
+
   //used to apply effect
   async function applyEffect(actor, selectedEffect) {
     const re = /\{(.*)\}/i
     let effectName = selectedEffect.match(re)[1]
-    const explorationEffects = {
-      'Avoid Notice':
-        'Compendium.pf2e-exploration-effects.exploration-effects.N8vpuGy4TzU10y8E',
-      'Cover Tracks':
-        'Compendium.pf2e-exploration-effects.exploration-effects.F6vJYLZTWDpnrnCZ',
-      Defend:
-        'Compendium.pf2e-exploration-effects.exploration-effects.GYOyFj4ziZX060rZ',
-      'Detect Magic':
-        'Compendium.pf2e-exploration-effects.exploration-effects.OjRHL0B4WAUUQc13',
-      'Follow the Expert':
-        'ompendium.pf2e-exploration-effects.exploration-effects.V347nnVBGDrVWh7k',
-      Hustle:
-        'Compendium.pf2e-exploration-effects.exploration-effects.vNUrKvoOSvEnqzhM',
-      Investigate:
-        'Compendium.pf2e-exploration-effects.exploration-effects.tDsgl8YmhZbx2May',
-      'Repeat a Spell':
-        'Compendium.pf2e-exploration-effects.exploration-effects.kh1QdKkvbNZ0qBsQ',
-      Scout:
-        'Compendium.pf2e-exploration-effects.exploration-effects.mGFBHM1lvHNZ9BsH',
-      Search:
-        'Compendium.pf2e-exploration-effects.exploration-effects.XiVLHjg5lQVMX8Fj',
-      Track:
-        'Compendium.pf2e-exploration-effects.exploration-effects.OcCXjJab7rSR3mDf',
-      Unspecified:
-        'Compendium.pf2e-exploration-effects.exploration-effects.CcyA2CzeaTBWHNHP',
-    }
-
     let effect = explorationEffects[effectName]
     if (effect != undefined) {
       let item = (await fromUuid(effect)).toObject()
       await token.actor.createEmbeddedDocuments('Item', [item])
+    }
+  }
+
+  //removes other exploration activities
+  async function removeExplorationEffects(actor) {
+    for (const effectName of Object.keys(explorationEffects)) {
+      for (const fx of token.actor.itemTypes.effect) {
+        if (fx.name == effectName) {
+          console.log('removing ' + fx.name)
+          await fx.delete()
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
With repeated use of the macros, the exploration effects can stack.  This change would prevent that by looping through effects on the selected tokens and deleting all matching exploration effects before applying the newly selected one.

This could also be extended to remove all exploration effects when selecting Cancel instead of an activity, but I think it makes more sense to just leave the current state on Cancel.